### PR TITLE
Yakuake script and paths  with weird characters.

### DIFF
--- a/yakuake-session
+++ b/yakuake-session
@@ -218,7 +218,7 @@ function yakuake_session() {
 
 	cat > "$SESSION_FILE" <<-EOF
 	clear
-	$(profile_setup_command) && cd '$cwd' && $cmd
+	$(profile_setup_command) && cd `printf %q "$cwd"` && $cmd
 	rm -f '$SESSION_FILE' &> /dev/null
 	EOF
 


### PR DESCRIPTION
Fixes issue #7. 
Tested for paths containing:
*) quotes '
*) doublequotes "
*) spaces 