### PR TITLE
Update ServiceMenus files

### DIFF
--- a/ServiceMenus/yakuakehere.desktop
+++ b/ServiceMenus/yakuakehere.desktop
@@ -5,11 +5,12 @@ Actions=openYakuakeHere;
 X-KDE-AuthorizeAction=shell_access
 
 [Desktop Action openYakuakeHere]
+TryExec=yakuake
+Exec=yakuake-session --workdir %f
+Icon=yakuake
+X-Ubuntu-Gettext-Domain=desktop_kdebase
+
 Name=Open Yakuake Here
 Name[ru]=Открыть Yakuake в этой папке
 Name[es]=Abrir Yakuake aquí
 Name[es_ES]=Abrir Yakuake aquí
-Icon=utilities-terminal
-Exec=yakuake-session --workdir %f
-#Exec=$HOME/.kde/share/kde4/services/ServiceMenus/yakuake-session --workdir %f
-X-Ubuntu-Gettext-Domain=desktop_kdebase

--- a/ServiceMenus/yakuakerun.desktop
+++ b/ServiceMenus/yakuakerun.desktop
@@ -6,7 +6,7 @@ Actions=runInYakuake;
 X-KDE-AuthorizeAction=shell_access
 
 [Desktop Action runInYakuake]
-TryExec=konsole
+TryExec=yakuake
 Exec=yakuake-session --hold -e %f
 Icon=yakuake
 


### PR DESCRIPTION
yakuakehere.desktop updates:
- Now it uses the yakuake icon instead the konsole one
- The keys were re-ordered to match konsolehere.desktop ordering
- A commented line was removed (if this is needed for KDE4 compatibility I will revert this change)

yakuakerun.desktop updates:
- The "TryExec" key was added