### PR TITLE
Remove subshell, yakuake takes care of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ of Konsole.
 breaks the command `qdbus` in Kubuntu 13.04/13.10. It can be fixed installing
 `qt4-default` package.
 
+ * Requires wmctrl to change focus if yakuake is already open. Get it from the repo e.g. `apt install wmctrl`
+
 ## Installation
 
 Clone this repository.
@@ -41,7 +43,7 @@ $ yakuake-session
 ```
 
 Without arguments, yakuake-session creates a new session in the currently
-running Yakuake terminal emulator. 
+running Yakuake terminal emulator.
 
 The option `-e` allows to indicate a command to execute in the new session.
 
@@ -103,7 +105,7 @@ Arguments:
 
 Dolphin provides the action "Open terminal here" that opens a Konsole terminal
 emulator in the specified folder. This behavior can be changed to use Yakuake
-instead of Konsole coping `konsolehere.desktop` into KDE Service Menus. 
+instead of Konsole coping `konsolehere.desktop` into KDE Service Menus.
 
 ```
 # KDE 4

--- a/yakuake-session
+++ b/yakuake-session
@@ -275,9 +275,6 @@ function yakuake_session() {
 	# Create a new terminal session in Yakuake
 	yakuake_addsession > /dev/null ||
 		error_exit 4 'cannot create a new session in Yakuake'
-	if [[ -n "$title" ]]; then
-		yakuake_settitle "$title"
-	fi
 
 	# Setup the session
 	SESSION_FILE="$(mktemp --tmpdir "$PROGRAM_NAME-XXXXXXXXXX")"
@@ -292,6 +289,10 @@ function yakuake_session() {
 	# We put a space before the command to exclude it from history
 	yakuake_runcommand " . '$SESSION_FILE'" ||
 		error_exit 7 'cannot run a command inside the new session'
+
+    if [[ -n "$title" ]]; then
+		yakuake_settitle "$title"
+	fi
 
 	# Show the window of Yakuake
 	if [[ "$now" == 1 ]]; then

--- a/yakuake-session
+++ b/yakuake-session
@@ -134,7 +134,7 @@ function init_ipc_interface() {
 			  cut -d ':' -f2 | tr ',' ' ')
 			for id in $ids; do
 				local wm_class=$(xprop -id $id 8s ':$0+' WM_CLASS | cut -d ':' -f2)
-				if [[ "$wm_class" == '"yakuake", "Yakuake"' ]]; then
+				if [[ "${wm_class,,}" == '"yakuake", "yakuake"' ]]; then
 					echo true
 					return
 				fi
@@ -155,6 +155,15 @@ function init_ipc_interface() {
 			local ws=$(yakuake_isvisible)
 			if [[ "$ws" != true ]]; then
 				qdbus org.kde.yakuake /yakuake/window toggleWindowState > /dev/null
+    		else
+    		    local ids=$(xprop -root 32x ':$0+' _NET_CLIENT_LIST_STACKING | cut -d ':' -f2 | tr ',' ' ')
+			    for id in $ids; do
+				    local wm_class=$(xprop -id $id 8s ':$0+' WM_CLASS | cut -d ':' -f2)
+				    if [[ "${wm_class,,}" == '"yakuake", "yakuake"' ]]; then
+                        wmctrl -i -a $id
+                        return
+                    fi
+                done
 			fi
 		}
 	elif [[ "$comm" == dcop ]]; then
@@ -280,7 +289,6 @@ function yakuake_session() {
     	cd $(printf %q "$cwd")
     	$cmd
 	EOF
-
 	# We put a space before the command to exclude it from history
 	yakuake_runcommand " . '$SESSION_FILE'" ||
 		error_exit 7 'cannot run a command inside the new session'

--- a/yakuake-session
+++ b/yakuake-session
@@ -15,7 +15,7 @@
 PROGRAM_NAME="$(basename "$0")"
 SESSION_FILE=''
 
-# Show information about how to use this program 
+# Show information about how to use this program
 function show_help() {
 	cat <<-EOF
 
@@ -114,7 +114,7 @@ function init_ipc_interface() {
 		function yakuake_settitle() {
 			local id="$(qdbus org.kde.yakuake /yakuake/sessions sessionIdList |
 				tr , "\n" | sort -g | tail -1 | tr -d '\n')"
-			qdbus org.kde.yakuake /yakuake/tabs setTabTitle "$id" "$1" 
+			qdbus org.kde.yakuake /yakuake/tabs setTabTitle "$id" "$1"
 		}
 
 		function yakuake_isvisible_by_dbus() {
@@ -275,14 +275,16 @@ function yakuake_session() {
 
 	cat > "$SESSION_FILE" <<-EOF
 		clear
-		rm -f '$SESSION_FILE' >/dev/null 2>&1
-		sh -c '$(profile_setup_command) && cd $(printf %q "$cwd") && $cmd'
+        rm -f '$SESSION_FILE' >/dev/null 2>&1
+    	$(profile_setup_command)
+    	cd $(printf %q "$cwd")
+    	$cmd
 	EOF
 
 	# We put a space before the command to exclude it from history
 	yakuake_runcommand " . '$SESSION_FILE'" ||
 		error_exit 7 'cannot run a command inside the new session'
-	
+
 	# Show the window of Yakuake
 	if [[ "$now" == 1 ]]; then
 		yakuake_showwindow


### PR DESCRIPTION
As of yakuake 3.0.4 at least yakuake-session stopped showing results because of the subshell execution. This change fixes it.