### PR TITLE
Fix small errata for fish shell

### DIFF
--- a/yakuake-session
+++ b/yakuake-session
@@ -310,7 +310,7 @@ function yakuake_session() {
 
 	# Setup the session
 	if [ "$FISH_SHELL" == 1 ]; then
-		AND_OP='and'
+		AND_OP='; and'
 	else
 		AND_OP='&&'
 	fi


### PR DESCRIPTION
Fish needs "; and" not "and" as AND operator. If not, will throw an error of "too many parameters for cd command"